### PR TITLE
Fix a layout bug

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -31,8 +31,13 @@ a:hover {
 }
 
 #uploaded-photo {
-  max-height: 500px;
   margin-bottom: 100px;
+}
+
+@media only screen and (min-width: 576px) {
+  #uploaded-photo {
+    max-height: 500px;
+  }
 }
 
 h2 {


### PR DESCRIPTION
When using the app on an iPhone, the bottom part of the featured match
is often obscured.  Which is a shame because that portrait totally looked
just like the Mrs.

This glitch manifested because of a maximum-height for a layout block
that collapses from horizontal to vertical stacking at small window
widths. We can safely stash that max-height declaration in a media-query
with a min-width and we should be golden.

## Before
<img width="451" alt="screen shot 2017-05-21 at 16 58 06" src="https://cloud.githubusercontent.com/assets/608867/26285474/82e57c38-3e48-11e7-8799-eb183d3384a4.png">

## After (probably)
<img width="545" alt="screen shot 2017-05-21 at 17 03 17" src="https://cloud.githubusercontent.com/assets/608867/26285478/8ce687fe-3e48-11e7-915d-c7dc678cb95c.png">


**DISCLAIMER: I haven't actually tested this but it looks plausible**